### PR TITLE
Threaded consumers.

### DIFF
--- a/moksha.hub/moksha/hub/api/consumer.py
+++ b/moksha.hub/moksha/hub/api/consumer.py
@@ -76,7 +76,7 @@ class Consumer(object):
             self.engine = create_app_engine(app, hub.config)
             self.DBSession = sessionmaker(bind=self.engine)()
 
-        self.N = int(self.hub.config.get('moksha.workers_per_consumer', 0))
+        self.N = int(self.hub.config.get('moksha.workers_per_consumer', 1))
         for i in range(self.N):
             moksha.hub.reactor.reactor.callInThread(self._work)
 
@@ -159,7 +159,7 @@ class Consumer(object):
                 self.validate(message)
             except Exception, e:
                 log.warn("Received invalid message %r" % e)
-                return
+                continue
 
             self.consume(message)
             self.debug("Going back to waiting on the incoming queue.")

--- a/moksha.hub/moksha/hub/api/consumer.py
+++ b/moksha.hub/moksha/hub/api/consumer.py
@@ -26,11 +26,15 @@ loaded, and receives each message for the specified topic through the
 """
 
 import json
+import threading
+import Queue as queue
 import logging
 log = logging.getLogger('moksha.hub')
 
+
 from kitchen.iterutils import iterate
 from moksha.common.lib.helpers import create_app_engine
+import moksha.hub.reactor
 
 
 class Consumer(object):
@@ -47,6 +51,12 @@ class Consumer(object):
     def __init__(self, hub):
         self.hub = hub
         self.log = log
+
+        # Set up a queue to communicate between the main twisted thread
+        # receiving raw messages, and a worker thread that pulls items off
+        # the queue to do "consume" work.
+        # TODO -- someday, have this be monitored by the monitoring socket
+        self.incoming = queue.Queue()
 
         callback = self._consume
         if self.jsonify:
@@ -66,6 +76,10 @@ class Consumer(object):
             self.engine = create_app_engine(app, hub.config)
             self.DBSession = sessionmaker(bind=self.engine)()
 
+        self.N = int(self.hub.config.get('moksha.workers_per_consumer', 0))
+        for i in range(self.N):
+            moksha.hub.reactor.reactor.callInThread(self._work)
+
         self._initialized = True
 
     def __json__(self):
@@ -77,6 +91,10 @@ class Consumer(object):
             "exceptions": self._exception_count,
             "jsonify": self.jsonify,
         }
+
+    def debug(self, message):
+        idx = threading.current_thread().ident
+        log.debug("%r thread %r | %s" % (type(self).__name__, idx, message))
 
     def _consume_json(self, message):
         """ Convert our AMQP messages into a consistent dictionary format.
@@ -125,13 +143,28 @@ class Consumer(object):
             raise
 
     def _consume(self, message):
-        try:
-            self.validate(message)
-        except Exception, e:
-            log.warn("Received invalid message %r" % e)
-            return
+        self.incoming.put(message)
 
-        self.consume(message)
+    def _work(self):
+        while True:
+            # This is a blocking call.  It waits until a message is available.
+            message = self.incoming.get()
+
+            # Then we are being asked to quit
+            if message is StopIteration:
+                break
+
+            self.debug("Worker thread picking up %r" % message)
+            try:
+                self.validate(message)
+            except Exception, e:
+                log.warn("Received invalid message %r" % e)
+                return
+
+            self.consume(message)
+            self.debug("Going back to waiting on the incoming queue.")
+
+        self.debug("Worker thread exiting.")
 
     def validate(self, message):
         """ Override to implement your own validation scheme. """
@@ -147,6 +180,9 @@ class Consumer(object):
             log.error('Cannot send message: %s' % e)
 
     def stop(self):
+        for i in range(getattr(self, 'N', 0)):
+            self.incoming.put(StopIteration)
+
         if hasattr(self, 'hub'):
             self.hub.close()
 

--- a/moksha.hub/moksha/hub/tests/test_hub.py
+++ b/moksha.hub/moksha/hub/tests/test_hub.py
@@ -149,7 +149,7 @@ class TestConsumer:
             jsonify = False
             topic = self.a_topic
 
-            def consume(self, message):
+            def _consume(self, message):
                 messages_received.append(message)
 
         self.fake_register_consumer(TestConsumer)
@@ -169,7 +169,7 @@ class TestConsumer:
         class TestConsumer(moksha.hub.api.consumer.Consumer):
             topic = self.a_topic
 
-            def consume(self, message):
+            def _consume(self, message):
                 messages_received.append(message['body'])
 
         self.fake_register_consumer(TestConsumer)
@@ -190,13 +190,13 @@ class TestConsumer:
         class TestConsumer1(moksha.hub.api.consumer.Consumer):
             topic = self.a_topic
 
-            def consume(self, message):
+            def _consume(self, message):
                 messages_received.append(message['body'])
 
         class TestConsumer2(moksha.hub.api.consumer.Consumer):
             topic = self.a_topic
 
-            def consume(self, message):
+            def _consume(self, message):
                 messages_received.append(message['body'])
 
         self.fake_register_consumer(TestConsumer1)
@@ -218,7 +218,7 @@ class TestConsumer:
         class BaseConsumer(moksha.hub.api.consumer.Consumer):
             topic = self.a_topic
 
-            def consume(self, message):
+            def _consume(self, message):
                 messages_received.append(message['body'])
 
         class Consumer1(BaseConsumer):
@@ -251,7 +251,7 @@ class TestConsumer:
         class TestConsumer(moksha.hub.api.consumer.Consumer):
             topic = self.a_topic
 
-            def consume(self, message):
+            def _consume(self, message):
                 obj = message['body']
                 messages_received.append(obj['secret'])
 
@@ -274,7 +274,7 @@ class TestConsumer:
         class TestConsumer(moksha.hub.api.consumer.Consumer):
             topic = self.a_topic
 
-            def consume(self, message):
+            def _consume(self, message):
                 messages_received.append(message['body'])
 
         self.fake_register_consumer(TestConsumer)
@@ -299,7 +299,7 @@ class TestConsumer:
         class TestConsumer(moksha.hub.api.consumer.Consumer):
             topic = self.a_topic
 
-            def consume(self, message):
+            def _consume(self, message):
                 messages_received.append(message['body'])
 
         self.fake_register_consumer(TestConsumer)
@@ -324,7 +324,7 @@ class TestConsumer:
                 super(TestConsumer, self).__init__(*args, **kw)
                 self.topic = "good topic"
 
-            def consume(self, message):
+            def _consume(self, message):
                 pass
 
         # Just a little fake config.
@@ -345,7 +345,7 @@ class TestConsumer:
         class TestConsumer(moksha.hub.api.consumer.Consumer):
             topic = "whatever"
 
-            def consume(self, message):
+            def _consume(self, message):
                 pass
 
         # Just a little fake config.


### PR DESCRIPTION
See http://threebean.org/blog/threading-moksha

This should break apart the consumers given each consumer its own thread(s)
fed by a thread-safe queue.
