### PR TITLE
Catch and log errors from consumers.

### DIFF
--- a/moksha.hub/moksha/hub/api/consumer.py
+++ b/moksha.hub/moksha/hub/api/consumer.py
@@ -170,7 +170,12 @@ class Consumer(object):
                 log.warn("Received invalid message %r" % e)
                 continue
 
-            self.consume(message)
+            try:
+                self.consume(message)
+            except Exception as e:
+                self.log.error("%r" % )message)
+                self.log.exception(e)
+
             self.debug("Going back to waiting on the incoming queue.")
 
         self.debug("Worker thread exiting.")

--- a/moksha.hub/moksha/hub/api/consumer.py
+++ b/moksha.hub/moksha/hub/api/consumer.py
@@ -173,8 +173,7 @@ class Consumer(object):
             try:
                 self.consume(message)
             except Exception as e:
-                self.log.error("%r" % message)
-                self.log.exception(e)
+                self.log.exception(message)
 
             self.debug("Going back to waiting on the incoming queue.")
 

--- a/moksha.hub/moksha/hub/api/consumer.py
+++ b/moksha.hub/moksha/hub/api/consumer.py
@@ -173,7 +173,7 @@ class Consumer(object):
             try:
                 self.consume(message)
             except Exception as e:
-                self.log.error("%r" % )message)
+                self.log.error("%r" % message)
                 self.log.exception(e)
 
             self.debug("Going back to waiting on the incoming queue.")


### PR DESCRIPTION
It used to be that if a consumer raised an error, that would bubble up
to Twisted's callback stuff and get logged, but then things would
proceed smoothly with the next message.

Now, with the threaded consumer stuff, if a consumer raised an uncaught
exception, it would break the consumer thread out of its `_work()`
loop and cause it to hang dead.  Messages would pile up.  Most recently,
this happened to our irc bot a few nights in a row.

This wraps a try block around the hand-off in that `_work()` method so
that if a consumer hits an exceptional condition, we can recover and
keep processing.

For fedmsg, `self.log.error` and `self.log.exception` will send
emails to members of sysadmin-datanommer... so we get to know about
these things when they happen.
