### PR TITLE
Suggest threadpool size to Twisted.

### DIFF
--- a/moksha.hub/development.ini
+++ b/moksha.hub/development.ini
@@ -80,6 +80,7 @@ app_db = sqlite:///%(here)s/moksha_app.db
 
 # A machine-local zeromq interprocess socket, typically
 moksha.monitoring.socket = ipc:///var/tmp/moksha-monitoring
+moksha.workers_per_consumer = 1
 
 # Automatically inject the Moksha live socket with
 # the Global Resource Injection Widget

--- a/moksha.hub/moksha/hub/__init__.py
+++ b/moksha.hub/moksha/hub/__init__.py
@@ -96,5 +96,15 @@ def main(options=None, consumers=None, producers=None, framework=True):
 
     log.info("Running the MokshaHub reactor")
     from moksha.hub.reactor import reactor
+
+    threadcount = config.get('moksha.threadpool_size', None)
+    if not threadcount:
+        N = int(config.get('moksha.workers_per_consumer', 1))
+        threadcount = 1 + hub.num_producers + hub.num_consumers * N
+
+    threadcount = int(threadcount)
+    log.info("Suggesting threadpool size at %i" % threadcount)
+    reactor.suggestThreadPoolSize(threadcount)
+
     reactor.run(installSignalHandlers=False)
     log.info("MokshaHub reactor stopped")

--- a/moksha.hub/moksha/hub/hub.py
+++ b/moksha.hub/moksha/hub/hub.py
@@ -331,6 +331,16 @@ class CentralMokshaHub(MokshaHub):
         self.local_queue.start()
         self.local_queue.listen(self.consume_amqp_message)
 
+    @property
+    def num_consumers(self):
+        return len([
+            c for c in self.consumers if getattr(c, '_initialized', None)])
+
+    @property
+    def num_producers(self):
+        return len([
+            p for p in self.producers if getattr(p, '_initialized', None)])
+
     def __init_consumers(self):
         """ Instantiate and run the consumers """
         log.info('Loading Consumers')


### PR DESCRIPTION
Take a guess at how many threads we need.  We need one for each consumer
thread, plus one for each producer, plus an extra "one to grow on".

This should let us scale the number of FMN workers past 4.  As things
stand now, if we ask for more than 4 FMN workers, then there isn't an
extra thread around to drive the monitoring polling producer, and NRPE
starts timing out due to lack of data.
