### PR TITLE
Configurable permissions on monitoring socket.

### DIFF
--- a/moksha.hub/development.ini
+++ b/moksha.hub/development.ini
@@ -81,6 +81,7 @@ app_db = sqlite:///%(here)s/moksha_app.db
 # A machine-local zeromq interprocess socket, typically
 moksha.monitoring.socket = ipc:///var/tmp/moksha-monitoring
 moksha.workers_per_consumer = 1
+moksha.monitoring.socket.mode = 770
 
 # Automatically inject the Moksha live socket with
 # the Global Resource Injection Widget

--- a/moksha.hub/moksha/hub/monitoring.py
+++ b/moksha.hub/moksha/hub/monitoring.py
@@ -60,9 +60,11 @@ class MonitoringProducer(PollingProducer):
             "consumers": self.serialize(self.hub.consumers),
             "producers": self.serialize(self.hub.producers),
         }
-        self.socket.send(json.dumps(data))
+        if self.socket:
+            self.socket.send(json.dumps(data))
 
     def stop(self):
+        super(MonitoringProducer, self).stop()
         if self.socket:
             self.socket.close()
             self.socket = None


### PR DESCRIPTION
We have the problem in the Fedora Infrastructure production environment
where moksha needs to be able to write to the socket, but nrpe needs to
also be able to write to the socket (to set its subscription). Currently,
we have the socket owned by fedmsg, but the gid is set to nrpe.  The
default permissions, however, are for read-only access on the group bits.

This change will allow us to tell moksha to set the permissions on the
socket to 0770 at startup, and thus will cut down on UNKNOWN responses from
nrpe.
