### PR TITLE
Stomp:  remember topics.

### DIFF
--- a/moksha.hub/moksha/hub/stomp/stomp.py
+++ b/moksha.hub/moksha/hub/stomp/stomp.py
@@ -111,7 +111,6 @@ class StompHubExtension(MessagingHubExtension, ClientFactory):
         for topic in self._topics:
             log.info('Subscribing to %s topic' % topic)
             self.subscribe(topic, callback=lambda msg: None)
-        self._topics = []
 
         for frame in self._frames:
             log.info('Flushing queued frame')


### PR DESCRIPTION
The gist is that, when the moksha hub first connects via stomp, it looks
at all the topics it is supposed to subscribe to, sends those over the
wire, then deletes that list it originally had.

Here's the bug I'm seeing:
- Startup, connect to $BROKER1
- Send subscription(s)
- Receive messages happily
- Lose connection to $BROKER1
- Connect to $BROKER2
- Wait for messages, but none arrive.  I need to send subscriptions.

Now that we have the failover/reconnect stuff, it needs to remember its
own list of topics so that it can send it again when it reconnects.
