### PR TITLE
Add support for iterable consumer/producer entry-points

### DIFF
--- a/docs/main/Consumers.rst
+++ b/docs/main/Consumers.rst
@@ -58,6 +58,12 @@ make it look something like this:
 
         """
 
+.. note::
+
+        You can also install a collection of consumers in the same manner.  Just
+        specify the name of an iterable object in place of the consumer class
+        name in the example above.  This even works with generator objects.
+
 After modifying your entry-points, you'll need to re-generate your project's `egg-info`.
 
 .. code-block:: bash

--- a/docs/main/Producers.rst
+++ b/docs/main/Producers.rst
@@ -41,3 +41,9 @@ in your `setup.py`, like so:
 
     [moksha.producer]
     hello = myproject.producers:HelloWorldProducer
+
+.. note::
+
+    Just as with consumers, you can also expose a collection of producers by
+    creating a list, generator object, etc. inside of your code and providing
+    that variable as an entry-point under `[moksha.producer]`.

--- a/moksha.hub/moksha/hub/hub.py
+++ b/moksha.hub/moksha/hub/hub.py
@@ -351,7 +351,10 @@ class CentralMokshaHub(MokshaHub):
             for consumer in pkg_resources.iter_entry_points('moksha.consumer'):
                 try:
                     c = consumer.load()
-                    self._consumers.append(c)
+                    try:
+                        self._consumers.extend(c) # assume to be collection
+                    except TypeError:
+                        self._consumers.append(c)
                 except Exception as e:
                     log.exception("Failed to load %r consumer." % consumer.name)
         else:
@@ -391,7 +394,10 @@ class CentralMokshaHub(MokshaHub):
             ], []):
                 try:
                     p = producer.load()
-                    self._producers.append(p)
+                    try:
+                        self._producers.extend(p) # assume to be collection
+                    except TypeError:
+                        self._producers.append(p)
                 except Exception as e:
                     log.exception("Failed to load %r producer." % producer.name)
         else:


### PR DESCRIPTION
This change allows the entry-points specified under `[moksha.{producer,consumer}]`
to be iterable objects. The idea here is that if users wish to dynamically generate or change their consumer or producer classes based on their app's configuration, they can expose a generator object to do just that. I could not figure out any other way to achieve that with moksha, but if there is, then this change is unnecessary.

Also, I know that the nested `try`/`except` is a little ugly, but that's done so we don't inadvertently catch a `TypeError` thrown by `{producer,consumer}.load()`.
