### PR TITLE
Export a list of the times taken to process each message.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,7 @@ Documentation
 
 http://moksha.rtfd.org/
 
+
 Build Status
 ------------
 

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,6 @@ Documentation
 
 http://moksha.rtfd.org/
 
-
 Build Status
 ------------
 


### PR DESCRIPTION
We can use this to graph more useful running stats in collectd. Notably, we
could graph the min, max, and average time taken to process. I want this in
particular for `datanommer`.  I have a hunch that the db `INSERT`
statements there get slower and slower over time until we go back and do a
`VACUUM ANALYZE;`, but I don't have data to back that up.  This should
let us see whether or not that's true.
