### PR TITLE
Less STOMP logging.

### DIFF
--- a/moksha.hub/moksha/hub/stomp/protocol.py
+++ b/moksha.hub/moksha/hub/stomp/protocol.py
@@ -61,7 +61,7 @@ class StompProtocol(Base):
         # https://stomp.github.io/stomp-specification-1.1.html#Heart-beating
         server_heartbeat = msg['headers'].get('heart-beat', 0)
         if server_heartbeat:
-            log.info("(server wants heart-beat (%s))" % server_heartbeat)
+            log.debug("(server wants heart-beat (%s))" % server_heartbeat)
             sx, sy = server_heartbeat.split(',')
             server_heartbeat = int(sy)
 
@@ -77,7 +77,7 @@ class StompProtocol(Base):
         generate an ack message.
         """
         #stomper.Engine.ack(self, msg)
-        #log.info("SENDER - received: %s " % msg['body'])
+        #log.debug("SENDER - received: %s " % msg['body'])
         return stomper.NO_REPONSE_NEEDED
 
     def subscribe(self, dest, **headers):
@@ -91,11 +91,11 @@ class StompProtocol(Base):
 
     def connectionMade(self):
         """ Register with stomp server """
-        log.info("Connecting with stomp-%s" % stomper.STOMP_VERSION)
+        log.debug("Connecting with stomp-%s" % stomper.STOMP_VERSION)
         if stomper.STOMP_VERSION != '1.0':
             host, port = self.client.addresses[self.client.address_index]
             interval = (self.client.client_heartbeat, 0)
-            log.info("(proposing heartbeat of (%i,%i))" % interval)
+            log.debug("(proposing heartbeat of (%i,%i))" % interval)
             cmd = stomper.connect(self.username, self.password, host, interval)
         else:
             cmd = stomper.connect(self.username, self.password)

--- a/moksha.hub/moksha/hub/stomp/stomp.py
+++ b/moksha.hub/moksha/hub/stomp/stomp.py
@@ -95,25 +95,25 @@ class StompHubExtension(MessagingHubExtension, ClientFactory):
 
     def buildProtocol(self, addr):
         self._delay = float(self.config.get('stomp_delay', '0.1'))
-        log.info("build protocol was called with %r" % addr)
+        log.debug("build protocol was called with %r" % addr)
         self.proto = StompProtocol(self, self.username, self.password)
         return self.proto
 
     def connected(self, server_heartbeat):
         if server_heartbeat and self.client_heartbeat:
             interval = max(self.client_heartbeat, server_heartbeat)
-            log.info("Heartbeat of %ims negotiated from (%i,%i); starting." % (
+            log.debug("Heartbeat of %ims negotiated from (%i,%i); starting." % (
                 interval, self.client_heartbeat, server_heartbeat))
             self.start_heartbeat(interval)
         else:
-            log.info("Skipping heartbeat initialization")
+            log.debug("Skipping heartbeat initialization")
 
         for topic in self._topics:
             log.info('Subscribing to %s topic' % topic)
             self.subscribe(topic, callback=lambda msg: None)
 
         for frame in self._frames:
-            log.info('Flushing queued frame')
+            log.debug('Flushing queued frame')
             self.proto.transport.write(frame.pack())
         self._frames = []
 
@@ -143,10 +143,10 @@ class StompHubExtension(MessagingHubExtension, ClientFactory):
             self.proto.transport.write(chr(0x0A))  # Lub-dub
             reactor.callLater(interval / 1000.0, self.heartbeat, interval)
         else:
-            log.info("(heartbeat stopped)")
+            log.debug("(heartbeat stopped)")
 
     def stop_heartbeat(self):
-        log.info("stopping heartbeat")
+        log.debug("stopping heartbeat")
         self._heartbeat_enabled = False
 
     def send_message(self, topic, message, **headers):
@@ -167,7 +167,7 @@ class StompHubExtension(MessagingHubExtension, ClientFactory):
             if topic not in self._topics:
                 self._topics.append(topic)
         else:
-            log.info("sending subscription to the protocol")
+            log.debug("sending subscription to the protocol")
             self.proto.subscribe(topic)
 
         super(StompHubExtension, self).subscribe(topic, callback)


### PR DESCRIPTION
All of that heartbeat-related logging was an artifact of when it was
being developed.  It is pretty noisy in a real deployment when it gets
bounced around between failover nodes and keeps re-negotiating the
heartbeat interval.  Best to tune that down to debug for when we need to
dig deeper.
