### PR TITLE
Pass STOMP headers along to consumers.

### DIFF
--- a/moksha.hub/moksha/hub/hub.py
+++ b/moksha.hub/moksha/hub/hub.py
@@ -190,7 +190,8 @@ class MokshaHub(object):
     def consume_stomp_message(self, message):
         from moksha.hub.reactor import reactor
 
-        topic = message['headers'].get('destination')
+        headers = message['headers']
+        topic = headers.get('destination')
         if not topic:
             log.debug("Got message without a topic: %r" % message)
             return
@@ -204,8 +205,9 @@ class MokshaHub(object):
             body = message['body']
 
         # feed all of our consumers
+        envelope = {'body': body, 'topic': topic, 'headers': headers}
         for callback in self.topics.get(topic, []):
-            reactor.callInThread(callback, {'body': body, 'topic': topic})
+            reactor.callInThread(callback, envelope)
 
 
 class CentralMokshaHub(MokshaHub):


### PR DESCRIPTION
I'd like to have this to try and debug fedora-infra/bugzilla2fedmsg#7.

Currently, the STOMP messages have a 'messageId' header that lets us
track them uniquely.  I want to figure out if it is _our_ bridge that is
duplicating messages, or if it is the ActiveMQ brokers, or if it is
bugzilla itself.  It's hard to tell at the moment, because we lose all
of this routing information.  I'm going to embed the headers in the
fedmsg message body itself, so we can go back and debug later.
