### PR TITLE
Shortcircuit topic subscriptions if not initialized.

### DIFF
--- a/moksha.hub/moksha/hub/hub.py
+++ b/moksha.hub/moksha/hub/hub.py
@@ -380,6 +380,7 @@ class CentralMokshaHub(MokshaHub):
                 if not getattr(c, "_initialized", None):
                     log.info("%s:%s not initialized." % (
                         c_class.__module__, c_class.__name__,))
+                    continue
 
                 self.consumers.append(c)
 


### PR DESCRIPTION
If a consumer is disabled (if it is not `_initialized`), then we should
not add its topics to the list of topics we consider for incoming
messages.

We didn't hit this bug with zeromq, because topic<->callback mapping
happens in a different place, but this is how it's done for STOMP and
AMQP.  We experienced the bug as messages be passed to Consumers which
were intentionally disabled -- no way to disable consumers!