### PR TITLE
Use unique IP addresses for socket binding

### DIFF
--- a/moksha.hub/moksha/hub/zeromq/zeromq.py
+++ b/moksha.hub/moksha/hub/zeromq/zeromq.py
@@ -97,7 +97,7 @@ class ZMQHubExtension(BaseZMQHubExtension):
             try:
                 self.pub_socket.bind(endpoint)
             except zmq.ZMQError:
-                map(self.pub_socket.bind, hostname2ipaddr(endpoint))
+                map(self.pub_socket.bind, set(hostname2ipaddr(endpoint)))
 
         # Factory used to lazily produce subsequent subscribers
         self.twisted_zmq_factory = txzmq.ZmqFactory()


### PR DESCRIPTION
Resolve situation when hostname2ipaddr returns the same IP multiple
times. Without this fix, it would raise as follows:

```
.
.
.
  File "/usr/lib/python2.7/site-packages/moksha/hub/zeromq/zeromq.py", line 101, in __init__
    map(self.pub_socket.bind, hostname2ipaddr(endpoint))
  File "zmq/backend/cython/socket.pyx", line 489, in zmq.backend.cython.socket.Socket.bind (zmq/backend/cython/socket.c:4824)
  File "zmq/backend/cython/checkrc.pxd", line 25, in zmq.backend.cython.checkrc._check_rc (zmq/backend/cython/socket.c:7055)
zmq.error.ZMQError: Address already in use
```