### PR TITLE
Bugfix for blocking mode.

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -116,6 +116,7 @@ orbited_scheme = http
 #stomp_pass = guest
 #stomp_ssl_crt = /path/to/an/optional.crt
 #stomp_ssl_key = /path/to/an/optional.key
+#stomp_ack_mode = auto
 
 # Optional AMQP Broker
 #amqp_broker = guest/guest@localhost

--- a/moksha.hub/development.ini
+++ b/moksha.hub/development.ini
@@ -123,6 +123,7 @@ orbited_scheme = http
 #stomp_pass = guest
 #stomp_ssl_crt = /path/to/an/optional.crt
 #stomp_ssl_key = /path/to/an/optional.key
+#stomp_ack_mode = auto
 
 # Optional AMQP Broker
 #amqp_broker = guest/guest@localhost

--- a/moksha.hub/moksha/hub/hub.py
+++ b/moksha.hub/moksha/hub/hub.py
@@ -224,13 +224,13 @@ class MokshaHub(object):
         for pattern, callbacks in self.topics.items():
             if fnmatch.fnmatch(topic, pattern):
                 for callback in callbacks:
-                    reactor.callInThread(callback, envelope)
+                    callback(envelope)
 
         # Others subscribe to a queue composed of many topics..
         subscription = headers.get('subscription')
         if subscription != topic:
             for callback in self.topics.get(subscription, []):
-                reactor.callInThread(callback, envelope)
+                callback(envelope)
 
 
 class CentralMokshaHub(MokshaHub):

--- a/moksha.hub/moksha/hub/hub.py
+++ b/moksha.hub/moksha/hub/hub.py
@@ -220,17 +220,21 @@ class MokshaHub(object):
         # feed all of our consumers
         envelope = {'body': body, 'topic': topic, 'headers': headers}
 
+        handled = True
+
         # Some consumers subscribe to topics directly
         for pattern, callbacks in self.topics.items():
             if fnmatch.fnmatch(topic, pattern):
                 for callback in callbacks:
-                    callback(envelope)
+                    handled = handled and callback(envelope)
 
         # Others subscribe to a queue composed of many topics..
         subscription = headers.get('subscription')
         if subscription != topic:
             for callback in self.topics.get(subscription, []):
-                callback(envelope)
+                handled = handled and callback(envelope)
+
+        return handled
 
 
 class CentralMokshaHub(MokshaHub):

--- a/moksha.hub/moksha/hub/stomp/protocol.py
+++ b/moksha.hub/moksha/hub/stomp/protocol.py
@@ -67,19 +67,6 @@ class StompProtocol(Base):
 
         self.client.connected(server_heartbeat)
 
-        #f = stomper.Frame()
-        #f.unpack(stomper.subscribe(topic))
-        #print f
-        #return f.pack()
-
-    def ack(self, msg):
-        """Processes the received message. I don't need to
-        generate an ack message.
-        """
-        #stomper.Engine.ack(self, msg)
-        #log.debug("SENDER - received: %s " % msg['body'])
-        return stomper.NO_REPONSE_NEEDED
-
     def subscribe(self, dest, **headers):
         f = stomper.Frame()
         if stomper.STOMP_VERSION != '1.0':

--- a/moksha.hub/moksha/hub/stomp/protocol.py
+++ b/moksha.hub/moksha/hub/stomp/protocol.py
@@ -112,5 +112,7 @@ class StompProtocol(Base):
            self.client.hub.consume_stomp_message(msg)
 
            returned = self.react(msg)
+
            if returned:
+               log.debug("StompProtocol response to message: %r", returned)
                self.transport.write(returned)

--- a/moksha.hub/moksha/hub/stomp/protocol.py
+++ b/moksha.hub/moksha/hub/stomp/protocol.py
@@ -109,8 +109,8 @@ class StompProtocol(Base):
            if msg is None:
                break
 
+           self.client.hub.consume_stomp_message(msg)
+
            returned = self.react(msg)
            if returned:
                self.transport.write(returned)
-
-           self.client.hub.consume_stomp_message(msg)

--- a/moksha.hub/moksha/hub/stomp/protocol.py
+++ b/moksha.hub/moksha/hub/stomp/protocol.py
@@ -69,10 +69,12 @@ class StompProtocol(Base):
 
     def subscribe(self, dest, **headers):
         f = stomper.Frame()
+        # https://stomp.github.io/stomp-specification-1.2.html#SUBSCRIBE_ack_Header
+        ack = self.client.hub.config.get('stomp_ack_mode', 'auto')
         if stomper.STOMP_VERSION != '1.0':
-            f.unpack(stomper.subscribe(dest, dest))
+            f.unpack(stomper.subscribe(dest, dest, ack=ack))
         else:
-            f.unpack(stomper.subscribe(dest))
+            f.unpack(stomper.subscribe(dest, ack=ack))
         f.headers.update(headers)
         self.transport.write(f.pack())
 


### PR DESCRIPTION
Blocking mode was introduced in #39, which made it so that messages
would not be pulled into internal queues off the external bus, but
instead handled directly, "blocking" execution.  This is desirable when
working with durable queues.

The "consumer" API was addressed in #39, but I missed this spot where
messages are slotted into twisted deferreds that sit in memory before
being passed to the consumer api.

This furthermore adds support to response to the stomp broker with ACKs or NACKs based on whether or not any of our consumers raised any exceptions.