### PR TITLE
fedorahosted is gone

### DIFF
--- a/moksha.common/setup.py
+++ b/moksha.common/setup.py
@@ -40,7 +40,7 @@ setup(
     description='Common components for Moksha',
     author='Luke Macken, John (J5) Palmieri, Mairin Duffy, and Ralph Bean',
     author_email='',
-    url='http://moksha.fedorahosted.org',
+    url='https://mokshaproject.net',
     install_requires=[
         "six",
         "decorator",

--- a/moksha.feeds/setup.py
+++ b/moksha.feeds/setup.py
@@ -27,7 +27,7 @@ setup(
     description='WSGI components for Moksha.',
     author='Luke Macken, John (J5) Palmieri, Mairin Duffy, and Ralph Bean',
     author_email='',
-    url='http://moksha.fedorahosted.org',
+    url='https://mokshaproject.net',
     install_requires=[
         "moksha.common",
         "moksha.wsgi",

--- a/moksha.hub/setup.py
+++ b/moksha.hub/setup.py
@@ -53,7 +53,7 @@ setup(
     description='Hub components for Moksha.',
     author='Luke Macken, John (J5) Palmieri, Mairin Duffy, and Ralph Bean',
     author_email='',
-    url='http://moksha.fedorahosted.org',
+    url='https://mokshaproject.net',
     install_requires=install_requires,
     packages=find_packages(exclude=['ez_setup']),
     include_package_data=True,

--- a/moksha.wsgi/setup.py
+++ b/moksha.wsgi/setup.py
@@ -41,7 +41,7 @@ setup(
     description='WSGI components for Moksha.',
     author='Luke Macken, John (J5) Palmieri, Mairin Duffy, and Ralph Bean',
     author_email='',
-    url='http://moksha.fedorahosted.org',
+    url='https://mokshaproject.net',
     install_requires=[
         "moksha.common>=1.0.6",
         "tw2.core",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     description='A platform for creating real-time web applications',
     author='Luke Macken, John (J5) Palmieri, Mairin Duffy, and Ralph Bean',
     author_email='',
-    url='http://moksha.fedorahosted.org',
+    url='https://mokshaproject.net',
     install_requires=[
         "moksha.hub>=1.0.0",
         "moksha.wsgi>=1.0.0",


### PR DESCRIPTION
this PR just updates urls in `setup.py` so that packages published to PyPI have right url.

there are plenty of more fedorahosted urls in this repo.