### PR TITLE
Prefer "original-destination" for STOMP topic.

### DIFF
--- a/moksha.hub/moksha/hub/hub.py
+++ b/moksha.hub/moksha/hub/hub.py
@@ -197,7 +197,14 @@ class MokshaHub(object):
         from moksha.hub.reactor import reactor
 
         headers = message['headers']
-        topic = headers.get('destination')
+
+        # Prefer "original-destination"
+        topic = headers.get('original-destination')
+
+        # ...but if it is not present, fall back to "destination"
+        if not topic:
+            topic = headers.get('destination')
+
         if not topic:
             log.debug("Got message without a topic: %r" % message)
             return


### PR DESCRIPTION
An upcoming version of activemq changes the meaning of the destination header.
We need to use original-destination instead.  See
https://issues.apache.org/jira/browse/AMQ-3146