### PR TITLE
only try to json-decode the message body if it's non-empty

### DIFF
--- a/moksha.hub/moksha/hub/hub.py
+++ b/moksha.hub/moksha/hub/hub.py
@@ -223,7 +223,10 @@ class MokshaHub(object):
 
         # FIXME: only do this if the consumer wants it `jsonified`
         try:
-            body = JSON.loads(message['body'])
+            if message['body']:
+                body = JSON.loads(message['body'])
+            else:
+                body = {}
         except Exception as e:
             log.warning('Cannot decode body from JSON: %s -> %r' % (e, message))
             #body = {}


### PR DESCRIPTION
Some messages convey all relevant information in their headers, and
have an empty string as their body. Currently these messages cause
exceptions when trying to decode them as json. This change handles
those messages without raising an exception. Consumers will see
no change in behavior, the message body will be passed through
unchanged, as before.