### PR TITLE
Stop testing moksha.feeds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ Paste*.egg
 moksha/tests/quickstarts/tg2app/devdata.db-journal
 *.coverage
 htmldoc
+*/.eggs/

--- a/.travis-dev-setup.sh
+++ b/.travis-dev-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 echo "Installing all packages in development mode"
-for package in moksha.{common,hub,wsgi,feeds}; do
+for package in moksha.{common,hub,wsgi}; do
     echo "[$package] Installing"
     pushd $package
     python setup.py develop

--- a/.travis-dev-setup.sh
+++ b/.travis-dev-setup.sh
@@ -1,10 +1,12 @@
 #!/bin/bash -e
 
+PACKAGES=${1:-common hub wsgi}
+
 echo "Installing all packages in development mode"
-for package in moksha.{common,hub,wsgi}; do
-    echo "[$package] Installing"
-    pushd $package
+for package in $PACKAGES; do
+    echo "[moksha.$package] Installing"
+    pushd moksha.$package
     python setup.py develop
     popd
-    echo "[$package] done."
+    echo "[moksha.$package] done."
 done

--- a/.travis-run-tests.sh
+++ b/.travis-run-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 echo "running all tests"
-for package in moksha.{common,hub,wsgi,feeds}; do
+for package in moksha.{common,hub,wsgi}; do
     echo "[$package] running tests"
     pushd $package
     python setup.py test

--- a/.travis-run-tests.sh
+++ b/.travis-run-tests.sh
@@ -1,10 +1,12 @@
 #!/bin/bash -e
 
+PACKAGES=${1:-common hub wsgi}
+
 echo "running all tests"
-for package in moksha.{common,hub,wsgi}; do
-    echo "[$package] running tests"
-    pushd $package
+for package in $PACKAGES; do
+    echo "[moksha.$package] running tests"
+    pushd moksha.$package
     python setup.py test
     popd
-    echo "[$package] done with tests"
+    echo "[moksha.$package] done with tests"
 done

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: python
-python:
- - "2.6"
- - "2.7"
-# Someday, soon.
-# - "3.2"
-install: ./.travis-dev-setup.sh
-script: ./.travis-run-tests.sh
+matrix:
+  include:
+  - python: 2.7
+    env: PACKAGES=common hub wsgi
+  - python: 3.6
+    env: PACKAGES=common hub
+install: ./.travis-dev-setup.sh $PACKAGES
+script: ./.travis-run-tests.sh $PACKAGES
 notifications:
     email: false
     irc:


### PR DESCRIPTION
In #54 it annoyingly broke the test suite, and I'm not sure anything actually
uses it.  Let's remove it from the test battery here for now while we consider
deleting it entirely.

I think it might only be used by that `mdemos` demo-ware stuff.