### PR TITLE
STOMP: wait at most 60 seconds between reconnect attempts

### DIFF
--- a/moksha.hub/moksha/hub/stomp/stomp.py
+++ b/moksha.hub/moksha/hub/stomp/stomp.py
@@ -140,7 +140,7 @@ class StompHubExtension(MessagingHubExtension, ClientFactory):
     def failover(self):
         self.address_index = (self.address_index + 1) % len(self.addresses)
         args = (self.addresses[self.address_index], self.key, self.crt,)
-        self._delay = self._delay * (1 + (2.0 / len(self.addresses)))
+        self._delay = min(60.0, self._delay * (1 + (2.0 / len(self.addresses))))
         log.info('(failover) reconnecting in %f seconds.' % self._delay)
         reactor.callLater(self._delay, self.connect, *args)
 


### PR DESCRIPTION
The STOMP extension uses an exponential backoff between reconnect
attempts when failing over between brokers. In a situation when no
brokers have been available for an extended period, this can lead
to an unreasonably long backoff, and cause unnecessary reconnect
delays once a broker becomes available. This change limits the
delay to 60 seconds.