### PR TITLE
prevent a possible memory leak in Consumer

### DIFF
--- a/moksha.hub/moksha/hub/api/consumer.py
+++ b/moksha.hub/moksha/hub/api/consumer.py
@@ -33,6 +33,7 @@ import logging
 log = logging.getLogger('moksha.hub')
 
 import six.moves.queue as queue
+from collections import deque
 
 from kitchen.iterutils import iterate
 from moksha.common.lib.helpers import create_app_engine
@@ -60,7 +61,7 @@ class Consumer(object):
         # the queue to do "consume" work.
         self.incoming = queue.Queue()
         self.headcount_in = self.headcount_out = 0
-        self._times = []
+        self._times = deque(maxlen=1024)
 
         callback = self._consume
         if self.jsonify:
@@ -99,7 +100,7 @@ class Consumer(object):
             backlog = self.incoming.qsize()
             headcount_out = self.headcount_out
             headcount_in = self.headcount_in
-            times = self._times
+            times = list(self._times)
         else:
             backlog = None
             headcount_out = headcount_in = 0
@@ -120,7 +121,7 @@ class Consumer(object):
         # Reset these counters before returning.
         self.headcount_out = self.headcount_in = 0
         self._exception_count = 0
-        self._times = []
+        self._times.clear()
         return results
 
     def debug(self, message):


### PR DESCRIPTION
The moksha.api.hub.consumer.Consumer class would record the time
taken to process every message by appending it to the _times list.
It assumed the MonitoringProducer would call __json__() every 5
seconds to read out the values and reset the list. If the
MonitoringProducer was not configued to run, which is common,
then the _times list grows forever, causing a memory leak.

This change replaces the list with a deque, with a maximum size of
1024 entries.