### PR TITLE
stomp: be more forgiving about non-utf-8 content

### DIFF
--- a/moksha.hub/moksha/hub/stomp/protocol.py
+++ b/moksha.hub/moksha/hub/stomp/protocol.py
@@ -111,7 +111,7 @@ class StompProtocol(Base):
 
     def dataReceived(self, data):
         """Data received, react to it and respond if needed """
-        self.buffer.appendData(data.decode('utf-8'))
+        self.buffer.appendData(data.decode('utf-8', errors='replace'))
         while True:
            msg = self.buffer.getOneMessage()
            if msg is None:


### PR DESCRIPTION
It's possible for clients to send data in non-utf-8 format. Right now,
this will cause the hub to traceback on message reception, and a
disconnect and failover. The traceback happens too early to inspect the
message content, so it is impossible to know which producer would need
to be fixed. This change allows the hub to receive non-utf-8 messages.
Messages in the database can be inspected for the Unicode replacement
character, to help fix misbehaving producers.