### PR TITLE
Send heartbeats twice as often.

### DIFF
--- a/moksha.hub/moksha/hub/stomp/stomp.py
+++ b/moksha.hub/moksha/hub/stomp/stomp.py
@@ -105,7 +105,13 @@ class StompHubExtension(MessagingHubExtension, ClientFactory):
             interval = max(self.client_heartbeat, server_heartbeat)
             log.debug("Heartbeat of %ims negotiated from (%i,%i); starting." % (
                 interval, self.client_heartbeat, server_heartbeat))
-            self.start_heartbeat(interval)
+            # According to STOMP documentation, we have negotiated a heartbeat
+            # of `interval` milliseconds and heartbeats must be sent *at least*
+            # that often.  Here, we'll send them twice as often to give plenty
+            # of room for latency.
+            # https://stomp.github.io/stomp-specification-1.2.html#Heart-beating
+            fudge_factor = 0.5
+            self.start_heartbeat(interval=(interval * fudge_factor))
         else:
             log.debug("Skipping heartbeat initialization")
 


### PR DESCRIPTION
According to the stomp docs, we negotiate a heartbeat with our
broker, and then must send hearbeats *at least* that often.
https://stomp.github.io/stomp-specification-1.2.html#Heart-beating

We're seeing lots of disconnects from the broker and recent logs
seen on the broker side suggest that the broker thinks the TCP
connection should be closed at about the same time we should've
sent a heartbeat.  It may be that we're regularly in a race
condition where our moksha client is trying to send a keepalive
heartbeat at the very end of the grace period and the message
gets to the broker only too late resulting in a disconnect.

The fudge factor here should give the client's message plenty of
time to get there.