### PR TITLE
Add support for stomp over TLS with SNI

### DIFF
--- a/moksha.hub/moksha/hub/stomp/stomp.py
+++ b/moksha.hub/moksha/hub/stomp/stomp.py
@@ -86,8 +86,9 @@ class StompHubExtension(MessagingHubExtension, ClientFactory):
                 with open(crt) as cert_file:
                     client_cert = ssl.PrivateCertificate.loadPEM(
                         key_file.read() + cert_file.read())
-
-            ssl_context = client_cert.options()
+            # connect SSL/TLS with SNI support (https://twistedmatrix.com/trac/ticket/5190)
+            # This requires service_identity module: https://pypi.python.org/pypi/service_identity
+            ssl_context = ssl.optionsForClientTLS(host.decode('utf-8'), clientCertificate=client_cert)
             reactor.connectSSL(host, int(port), self, ssl_context)
         else:
             log.info("connecting unencrypted to %r %r %r" % (

--- a/moksha.hub/setup.py
+++ b/moksha.hub/setup.py
@@ -30,6 +30,8 @@ install_requires = [
     "pyzmq",
     "txZMQ",
     "txWS",
+    "service_identity",
+    "pyasn1",
     #"python-daemon",
 ]
 


### PR DESCRIPTION
[Server Name Indication (SNI)][1] makes it possible to make a encrypted connection
to a stomp server behind a reverse TLS proxy.
The purpose of this pull-request is to allow Moksha Hub to connect
to a TLS-encrypted stomp service exported by [OpenShift routes][2].

[1]: https://en.wikipedia.org/wiki/Server_Name_Indication
[2]: https://docs.openshift.com/container-platform/3.11/architecture/networking/routes.html

@ralphbean Hi, we are running test instances of UMB on OpenShift. To connect to a UMB stomp broker on OpenShift, the SNI support is required. Otherwise the OpenShift Router can't forward the TLS connection to correct pods. 