### PR TITLE
Make SNI optional.

### DIFF
--- a/moksha.hub/setup.py
+++ b/moksha.hub/setup.py
@@ -30,9 +30,11 @@ install_requires = [
     "pyzmq",
     "txZMQ",
     "txWS",
-    "service_identity",
-    "pyasn1",
     #"python-daemon",
+
+    # Optional
+    #"service_identity",
+    #"pyasn1",
 ]
 
 tests_require = [


### PR DESCRIPTION
Turns out python-service-identity (and python-characteristic) are not available
in epel7 and it will be a pain to get them reviewed and packaged.

Make this optional so we can still build there.

This is response to @vfreex's #66.