### PR TITLE
stomp.py: use six.text_type() instead of decode()

### DIFF
--- a/moksha.hub/moksha/hub/stomp/stomp.py
+++ b/moksha.hub/moksha/hub/stomp/stomp.py
@@ -91,7 +91,7 @@ class StompHubExtension(MessagingHubExtension, ClientFactory):
                 import service_identity
                 # connect SSL/TLS with SNI support (https://twistedmatrix.com/trac/ticket/5190)
                 # This requires service_identity module: https://pypi.python.org/pypi/service_identity
-                ssl_context = ssl.optionsForClientTLS(host.decode('utf-8'), clientCertificate=client_cert)
+                ssl_context = ssl.optionsForClientTLS(six.text_type(host), clientCertificate=client_cert)
             except ImportError:
                 log.warn("Connecting without SNI support due to absence of service_identity module.")
                 ssl_context = client_cert.options()


### PR DESCRIPTION
b60f601 added support for SNI to the STOMP protocol. The optionsForClientTLS()
API states that the hostname argument must be in unicode format, but under
Python 3 the argument is a str which doesn't provide a decode() method. Use
six.text_type() to ensure the proper type is always used.

This was reported in #69.