### PR TITLE
Properly stop the Twisted Reactor when a STOMP error is encountered

### DIFF
--- a/moksha.hub/moksha/hub/stomp/protocol.py
+++ b/moksha.hub/moksha/hub/stomp/protocol.py
@@ -102,7 +102,7 @@ class StompProtocol(Base):
         super(StompProtocol, self).error(msg)
         log.error("Requesting shutdown of hub for STOMP error.")
         reactor.callLater(0, self.client.hub.close)
-        reactor.callLater(0, reactor.close)
+        reactor.callLater(0, reactor.stop)
 
     def ack(self, msg):
         """ Override stomper's own ack to be smarter, based on mode. """


### PR DESCRIPTION
A non-existent method of "close" was called on the reactor. It should be "stop" instead as shown in the documentation below.
https://twistedmatrix.com/documents/13.1.0/api/twisted.internet.interfaces.IReactorCore.html#stop