### PR TITLE
Require setuptools on runtime, moksha uses pkg_resources

### DIFF
--- a/moksha.common/setup.py
+++ b/moksha.common/setup.py
@@ -46,6 +46,7 @@ setup(
         "decorator",
         "pytz",
         "kitchen",
+        "setuptools",  # needed for pkg_resources
     ],
     classifiers = [
         "Development Status :: 5 - Production/Stable",

--- a/moksha.feeds/setup.py
+++ b/moksha.feeds/setup.py
@@ -34,6 +34,7 @@ setup(
         "shove <= 0.3.3",
         "feedcache",
         "feedparser",
+        "setuptools",  # needed for pkg_resources
     ],
     packages=find_packages(exclude=['ez_setup']),
     include_package_data=True,

--- a/moksha.hub/setup.py
+++ b/moksha.hub/setup.py
@@ -32,6 +32,9 @@ install_requires = [
     "txWS",
     #"python-daemon",
 
+    # Needed for pkg_resources
+    "setuptools",
+
     # Optional
     #"service_identity",
     #"pyasn1",

--- a/moksha.wsgi/setup.py
+++ b/moksha.wsgi/setup.py
@@ -61,6 +61,9 @@ setup(
 
         # Needed for the source code widget.
         "pygments",
+
+        # Needed for pkg_resources
+        "setuptools",
     ],
     packages=find_packages(exclude=['ez_setup']),
     include_package_data=True,


### PR DESCRIPTION
The pkg_resources module is only available when setuptools is installed.