### PR TITLE
Fix the issue of failed loading of the cache module.

### DIFF
--- a/moksha.common/moksha/common/lib/cache.py
+++ b/moksha.common/moksha/common/lib/cache.py
@@ -16,7 +16,7 @@
 import logging
 log = logging.getLogger(__name__)
 
-from moksha.exc import CacheBackendException
+from moksha.common.exc import CacheBackendException
 
 class Cache(object):
     """ A memcached-specific caching interface """


### PR DESCRIPTION
When loading the cache module, a prompt appears 
indicating  that the module 'moksha.exc' cannot be found.